### PR TITLE
Add unit test suite and CI coverage pipeline

### DIFF
--- a/.github/workflows/build-and-push-test.yml
+++ b/.github/workflows/build-and-push-test.yml
@@ -5,8 +5,18 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
+  test:
+    name: Unit tests with coverage
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+
   build:
+    name: Build and push Docker image
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-name: "Check for an update changelog"
+name: Changelog check
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,25 +1,26 @@
-name: Build and push
+name: PR build
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
+  test:
+    name: Unit tests with coverage
+    uses: ./.github/workflows/unit-tests.yml
+    secrets: inherit
+
   build:
+    name: Build and push PR Docker image
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set env
-        run: echo "APP_VERSION=$(grep -m 1 -Po '[0-9]+[.][0-9]+[.][0-9]+' CHANGELOG.md)" >> $GITHUB_ENV
-
-      - name: Show version
-        run: echo ${{ env.APP_VERSION }}
-
-      - name: Replace secrets
-        run: python replace-variables.py ./src/app/app.module.ts GOOGLE_ID_TRACKING=${{ secrets.GOOGLE_ID_TRACKING }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -38,5 +39,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: lmalvarez/personal-website:${{ env.APP_VERSION }},lmalvarez/personal-website:latest
+          tags: lmalvarez/personal-website:test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,26 @@
-name: Build and push Test version
+name: Release
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 
-permissions:
-  contents: read
-
 jobs:
-  test:
-    name: Unit tests with coverage
-    uses: ./.github/workflows/test.yml
-    secrets: inherit
-
   build:
-    name: Build and push Docker image
-    needs: test
+    name: Build and push release Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set env
+        run: echo "APP_VERSION=$(grep -m 1 -Po '[0-9]+[.][0-9]+[.][0-9]+' CHANGELOG.md)" >> $GITHUB_ENV
+
+      - name: Show version
+        run: echo ${{ env.APP_VERSION }}
+
+      - name: Replace secrets
+        run: python replace-variables.py ./src/app/app.module.ts GOOGLE_ID_TRACKING=${{ secrets.GOOGLE_ID_TRACKING }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -39,4 +39,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: lmalvarez/personal-website:test
+          tags: lmalvarez/personal-website:${{ env.APP_VERSION }},lmalvarez/personal-website:latest
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,69 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  test:
+    name: Unit tests with coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests with coverage
+        run: npx ng test --no-watch --browsers=ChromeHeadlessCI --code-coverage
+
+      - name: Check coverage summary
+        run: |
+          if [ -f coverage/personal-website/lcov.info ]; then
+            echo "Coverage report generated successfully."
+            echo "---"
+            cat coverage/personal-website/coverage-summary.txt || true
+          else
+            echo "::error::Coverage report was not generated."
+            exit 1
+          fi
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/personal-website
+          retention-days: 14
+
+      - name: Upload coverage to Codecov
+        if: always() && env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/personal-website/lcov.info
+          flags: unit
+          fail_ci_if_error: false
+          verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_call:
 
 permissions:
@@ -59,7 +62,8 @@ jobs:
           retention-days: 14
 
       - name: Upload coverage to Codecov
-        if: always() && env.CODECOV_TOKEN != ''
+        # Skip on pull_request: only push to main (or a workflow_call from main) should publish coverage
+        if: always() && env.CODECOV_TOKEN != '' && github.event.pull_request == null
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -67,3 +71,4 @@ jobs:
           flags: unit
           fail_ci_if_error: false
           verbose: true
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,10 +1,7 @@
-name: Tests
+name: Unit tests
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
     branches:
       - main
   workflow_call:
@@ -62,7 +59,7 @@ jobs:
           retention-days: 14
 
       - name: Upload coverage to Codecov
-        # Skip on pull_request: only push to main (or a workflow_call from main) should publish coverage
+        # Skip when called from a PR context: only push to main should publish coverage
         if: always() && env.CODECOV_TOKEN != '' && github.event.pull_request == null
         uses: codecov/codecov-action@v4
         with:
@@ -71,4 +68,5 @@ jobs:
           flags: unit
           fail_ci_if_error: false
           verbose: true
+
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ Personal Web Page
 ## [2.4.0] - 13/06/2026
 ### Added
 - Comprehensive unit test suite: 87 tests covering all HTTP services (login, profile, notification, user, CommonError), auth helpers (TokenService, AuthGuardGuard, BasicAuthInterceptor), the `RevealDirective` (with mocked `IntersectionObserver` and `fakeAsync/tick` fallback), the `ToastsContainerComponent`, `AppComponent` and the `User`/`Profile`/`Project`/`Knowledge`/`UserNotification`/`ProfileData` models
-- Reusable GitHub Actions workflow (`.github/workflows/test.yml`) running unit tests with coverage on every push to `main` and callable via `workflow_call`; uploads the HTML/lcov report as an artifact and (if `CODECOV_TOKEN` is configured) to Codecov
+- Reusable GitHub Actions workflow (`.github/workflows/unit-tests.yml`) running unit tests with coverage on every push to `main` and callable via `workflow_call`; uploads the HTML/lcov report as an artifact and (if `CODECOV_TOKEN` is configured) to Codecov
 - Test command in CI runs `ng test --no-watch --browsers=ChromeHeadlessCI --code-coverage`; the karma config auto-switches to headless when `CI=true`
 ### Changed
-- `build-and-push-test.yml` now calls the reusable test workflow and the Docker build has `needs: test`, so the image is only pushed when all tests pass
+- Workflows renamed for a coherent `kebab-case` noun-based convention:
+  - `test.yml` → `unit-tests.yml`
+  - `build-and-push-test.yml` → `pr-build.yml`
+  - `build-and-push.yml` → `release.yml`
+  - `changelog_enforcer.yml` → `changelog.yml`
+- `pr-build.yml` now calls the reusable `unit-tests.yml` workflow and the Docker build has `needs: test`, so the PR image is only pushed when all tests pass; tests run exactly once per PR (no duplicate execution)
 - `karma.conf.js` now detects `CI` env var to switch the launcher and disable watch mode; added a `ChromeHeadlessCI` launcher with `--no-sandbox`, `--disable-gpu`, `--disable-dev-shm-usage` and `--headless=new` flags
 - Replaced deprecated `karma-coverage-istanbul-reporter` (~3.0.3) with the standard `karma-coverage` (~2.2.1) required by `@angular-devkit/build-angular` v21; migrated the config from `coverageIstanbulReporter` to `coverageReporter` producing `html`, `text-summary` and `lcovonly` reports
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 Personal Web Page
 
+## [2.4.0] - 13/06/2026
+### Added
+- Comprehensive unit test suite: 87 tests covering all HTTP services (login, profile, notification, user, CommonError), auth helpers (TokenService, AuthGuardGuard, BasicAuthInterceptor), the `RevealDirective` (with mocked `IntersectionObserver` and `fakeAsync/tick` fallback), the `ToastsContainerComponent`, `AppComponent` and the `User`/`Profile`/`Project`/`Knowledge`/`UserNotification`/`ProfileData` models
+- Reusable GitHub Actions workflow (`.github/workflows/test.yml`) running unit tests with coverage on every push to `main` and callable via `workflow_call`; uploads the HTML/lcov report as an artifact and (if `CODECOV_TOKEN` is configured) to Codecov
+- Test command in CI runs `ng test --no-watch --browsers=ChromeHeadlessCI --code-coverage`; the karma config auto-switches to headless when `CI=true`
+### Changed
+- `build-and-push-test.yml` now calls the reusable test workflow and the Docker build has `needs: test`, so the image is only pushed when all tests pass
+- `karma.conf.js` now detects `CI` env var to switch the launcher and disable watch mode; added a `ChromeHeadlessCI` launcher with `--no-sandbox`, `--disable-gpu`, `--disable-dev-shm-usage` and `--headless=new` flags
+- Replaced deprecated `karma-coverage-istanbul-reporter` (~3.0.3) with the standard `karma-coverage` (~2.2.1) required by `@angular-devkit/build-angular` v21; migrated the config from `coverageIstanbulReporter` to `coverageReporter` producing `html`, `text-summary` and `lcovonly` reports
+### Fixed
+- `src/test.ts` import updated from `'zone.js/dist/zone-testing'` to `'zone.js/testing'`, which is the correct subpath export for `zone.js` 0.16+
+
 ## [2.3.0] - 13/06/2026
 ### Added
 - Dashboard with profile metrics (projects, knowledges, notifications), top skills and recent notifications

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,8 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
+const isCi = process.env.CI === 'true' || process.env.CI === '1';
+
 module.exports = function (config) {
   config.set({
     basePath: '',
@@ -9,24 +11,49 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
-      require('karma-coverage-istanbul-reporter'),
+      require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
-    coverageIstanbulReporter: {
+    coverageReporter: {
       dir: require('path').join(__dirname, './coverage/personal-website'),
-      reports: ['html', 'lcovonly', 'text-summary'],
-      fixWebpackSourcePaths: true
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' },
+        { type: 'lcovonly' }
+      ]
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false,
-    restartOnFileChange: true
+    autoWatch: !isCi,
+    browsers: isCi ? ['ChromeHeadlessCI'] : ['Chrome'],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--no-sandbox',
+          '--disable-gpu',
+          '--disable-dev-shm-usage'
+        ]
+      },
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--no-sandbox',
+          '--disable-gpu',
+          '--disable-dev-shm-usage',
+          '--headless=new',
+          '--remote-debugging-port=9222'
+        ]
+      }
+    },
+    singleRun: isCi,
+    restartOnFileChange: !isCi
   });
 };
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "personal-website",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "personal-website",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "@angular/animations": "^21.2.0",
         "@angular/common": "^21.2.0",
@@ -40,7 +40,7 @@
         "jasmine-core": "^6.0.0",
         "karma": "^6.4.4",
         "karma-chrome-launcher": "^3.2.0",
-        "karma-coverage-istanbul-reporter": "~3.0.3",
+        "karma-coverage": "~2.2.1",
         "karma-jasmine": "^5.0.0",
         "karma-jasmine-html-reporter": "^2.0.0",
         "ts-node": "~10.9.0",
@@ -9986,91 +9986,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/istanbul-lib-coverage": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -10315,21 +10230,74 @@
         "which": "bin/which"
       }
     },
-    "node_modules/karma-coverage-istanbul-reporter": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/karma-coverage-istanbul-reporter/-/karma-coverage-istanbul-reporter-3.0.3.tgz",
-      "integrity": "sha512-wE4VFhG/QZv2Y4CdAYWDbMmcAHeS926ZIji4z+FkB2aF/EposRb6DP6G5ncT/wXhqUfAb/d7kZrNKPonbvsATw==",
+    "node_modules/karma-coverage": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.2.1.tgz",
+      "integrity": "sha512-yj7hbequkQP2qOSb20GuNSIyE//PgJWHwC2IydLE6XRtsnaflv+/OSGNssPjobYUlhVVagy99TQpqUt3vAUG7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-instrument": "^5.1.0",
         "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^3.0.2",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.0.5",
         "minimatch": "^3.0.4"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/mattlewis92"
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/karma-jasmine": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-website",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -41,7 +41,7 @@
     "jasmine-core": "^6.0.0",
     "karma": "^6.4.4",
     "karma-chrome-launcher": "^3.2.0",
-    "karma-coverage-istanbul-reporter": "~3.0.3",
+    "karma-coverage": "~2.2.1",
     "karma-jasmine": "^5.0.0",
     "karma-jasmine-html-reporter": "^2.0.0",
     "ts-node": "~10.9.0",

--- a/src/app/_directives/reveal.directive.spec.ts
+++ b/src/app/_directives/reveal.directive.spec.ts
@@ -1,0 +1,182 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+
+import { RevealDirective } from './reveal.directive';
+
+interface ObserverEntry {
+  isIntersecting: boolean;
+}
+
+type ObserverCallback = (entries: ObserverEntry[]) => void;
+
+class MockIntersectionObserver {
+  public static instances: MockIntersectionObserver[] = [];
+  public static lastInstance(): MockIntersectionObserver | undefined {
+    return this.instances[this.instances.length - 1];
+  }
+  public callback: ObserverCallback;
+  public observed: Element[] = [];
+  public options: IntersectionObserverInit | undefined;
+  public unobserveCalls = 0;
+  public disconnectCalls = 0;
+
+  constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
+    this.callback = callback;
+    this.options = options;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(el: Element): void {
+    this.observed.push(el);
+  }
+
+  unobserve(el: Element): void {
+    this.unobserveCalls += 1;
+    this.observed = this.observed.filter(o => o !== el);
+  }
+
+  disconnect(): void {
+    this.disconnectCalls += 1;
+  }
+
+  trigger(entries: ObserverEntry[]): void {
+    this.callback(entries);
+  }
+}
+
+@Component({
+  standalone: false,
+  template: `
+    <div
+      #host
+      appReveal
+      [revealDirection]="direction"
+      [revealDelay]="delay"
+      [revealThreshold]="threshold"
+      [revealOnce]="once"
+      [revealFallbackMs]="fallbackMs"
+    >content</div>
+  `
+})
+class HostComponent {
+  direction: any = 'up';
+  delay = 0;
+  threshold = 0.12;
+  once = true;
+  fallbackMs = 800;
+}
+
+describe('RevealDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let hostElement: HTMLElement;
+  let originalIO: any;
+
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    originalIO = (globalThis as any).IntersectionObserver;
+    (globalThis as any).IntersectionObserver = MockIntersectionObserver;
+  });
+
+  afterEach(() => {
+    (globalThis as any).IntersectionObserver = originalIO;
+  });
+
+  const configure = (overrides: Partial<HostComponent> = {}) => {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent, RevealDirective]
+    });
+    fixture = TestBed.createComponent(HostComponent);
+    Object.assign(fixture.componentInstance, overrides);
+    fixture.detectChanges();
+    hostElement = fixture.nativeElement.querySelector('div') as HTMLElement;
+  };
+
+  it('should add reveal and reveal-direction classes to the host element', () => {
+    configure({ direction: 'left' });
+
+    expect(hostElement.classList.contains('reveal')).toBeTrue();
+    expect(hostElement.classList.contains('reveal-left')).toBeTrue();
+  });
+
+  it('should default to the "up" direction', () => {
+    configure();
+
+    expect(hostElement.classList.contains('reveal-up')).toBeTrue();
+  });
+
+  it('should apply the transition delay when revealDelay is set', () => {
+    configure({ delay: 250 });
+
+    expect(hostElement.style.transitionDelay).toBe('250ms');
+  });
+
+  it('should not apply a transition delay when revealDelay is 0', () => {
+    configure({ delay: 0 });
+
+    expect(hostElement.style.transitionDelay).toBe('');
+  });
+
+  it('should create an IntersectionObserver with the configured threshold', () => {
+    configure({ threshold: 0.5 });
+
+    const observer = MockIntersectionObserver.lastInstance()!;
+    expect(observer).toBeTruthy();
+    expect(observer.options?.threshold).toBe(0.5);
+  });
+
+  it('should observe the host element', () => {
+    configure();
+
+    const observer = MockIntersectionObserver.lastInstance()!;
+    expect(observer.observed).toContain(hostElement);
+  });
+
+  it('should add the "revealed" class and unobserve when intersecting (revealOnce = true)', () => {
+    configure({ once: true });
+    const observer = MockIntersectionObserver.lastInstance()!;
+
+    observer.trigger([{ isIntersecting: true }]);
+
+    expect(hostElement.classList.contains('revealed')).toBeTrue();
+    expect(observer.unobserveCalls).toBe(1);
+  });
+
+  it('should remove the "revealed" class on leave when revealOnce = false', () => {
+    configure({ once: false });
+    const observer = MockIntersectionObserver.lastInstance()!;
+
+    observer.trigger([{ isIntersecting: true }]);
+    expect(hostElement.classList.contains('revealed')).toBeTrue();
+    expect(observer.unobserveCalls).toBe(0);
+
+    observer.trigger([{ isIntersecting: false }]);
+    expect(hostElement.classList.contains('revealed')).toBeFalse();
+  });
+
+  it('should fallback to "revealed" after the configured timeout when never intersecting', fakeAsync(() => {
+    configure({ fallbackMs: 500 });
+
+    expect(hostElement.classList.contains('revealed')).toBeFalse();
+
+    tick(500);
+
+    expect(hostElement.classList.contains('revealed')).toBeTrue();
+  }));
+
+  it('should skip creating an IntersectionObserver and reveal immediately when IO is undefined', () => {
+    (globalThis as any).IntersectionObserver = undefined;
+    configure();
+
+    expect(MockIntersectionObserver.instances.length).toBe(0);
+    expect(hostElement.classList.contains('revealed')).toBeTrue();
+  });
+
+  it('should disconnect the observer when the host component is destroyed', () => {
+    configure();
+    const observer = MockIntersectionObserver.lastInstance()!;
+
+    fixture.destroy();
+
+    expect(observer.disconnectCalls).toBe(1);
+  });
+});

--- a/src/app/_helpers/auth-guard.guard.spec.ts
+++ b/src/app/_helpers/auth-guard.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+
+import { AuthGuardGuard } from './auth-guard.guard';
+import { TokenService } from '../_services/token.service';
+
+describe('AuthGuardGuard', () => {
+  let guard: AuthGuardGuard;
+  let tokenServiceSpy: jasmine.SpyObj<TokenService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  const dummyRoute = {} as ActivatedRouteSnapshot;
+  const dummyState = {} as RouterStateSnapshot;
+
+  beforeEach(() => {
+    tokenServiceSpy = jasmine.createSpyObj('TokenService', ['isAuthenticated']);
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthGuardGuard,
+        { provide: TokenService, useValue: tokenServiceSpy },
+        { provide: Router, useValue: routerSpy }
+      ]
+    });
+
+    guard = TestBed.inject(AuthGuardGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should allow navigation when the user is authenticated', () => {
+    tokenServiceSpy.isAuthenticated.and.returnValue(true);
+
+    const result = guard.canActivate(dummyRoute, dummyState);
+
+    expect(result).toBeTrue();
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should block navigation and redirect to /login when the user is not authenticated', () => {
+    tokenServiceSpy.isAuthenticated.and.returnValue(false);
+
+    const result = guard.canActivate(dummyRoute, dummyState);
+
+    expect(result).toBeFalse();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['login']);
+  });
+});

--- a/src/app/_helpers/basic-auth-interceptor.spec.ts
+++ b/src/app/_helpers/basic-auth-interceptor.spec.ts
@@ -1,0 +1,97 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpEvent, HttpHandler, HttpRequest, HttpResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { NgxSpinnerService } from 'ngx-spinner';
+
+import { BasicAuthInterceptor } from './basic-auth-interceptor';
+import { TokenService } from '../_services/token.service';
+
+describe('BasicAuthInterceptor', () => {
+  let interceptor: BasicAuthInterceptor;
+  let tokenServiceSpy: jasmine.SpyObj<TokenService>;
+  let spinnerSpy: jasmine.SpyObj<NgxSpinnerService>;
+  let handlerSpy: jasmine.SpyObj<HttpHandler>;
+  const mockResponse = new HttpResponse({ body: { ok: true } });
+
+  beforeEach(() => {
+    tokenServiceSpy = jasmine.createSpyObj('TokenService', ['getToken', 'isAuthenticated']);
+    spinnerSpy = jasmine.createSpyObj('NgxSpinnerService', ['show', 'hide']);
+    spinnerSpy.show.and.returnValue(Promise.resolve());
+    spinnerSpy.hide.and.returnValue(Promise.resolve());
+    handlerSpy = jasmine.createSpyObj('HttpHandler', ['handle']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        BasicAuthInterceptor,
+        { provide: TokenService, useValue: tokenServiceSpy },
+        { provide: NgxSpinnerService, useValue: spinnerSpy }
+      ]
+    });
+
+    interceptor = TestBed.inject(BasicAuthInterceptor);
+  });
+
+  it('should be created', () => {
+    expect(interceptor).toBeTruthy();
+  });
+
+  it('should add Authorization header when the user is authenticated', () => {
+    tokenServiceSpy.getToken.and.returnValue('jwt-token');
+    tokenServiceSpy.isAuthenticated.and.returnValue(true);
+    handlerSpy.handle.and.callFake((req: HttpRequest<any>) => of(mockResponse as HttpEvent<any>));
+
+    const req = new HttpRequest('GET', '/api/data');
+    interceptor.intercept(req, handlerSpy).subscribe();
+
+    const sent = handlerSpy.handle.calls.first().args[0] as HttpRequest<any>;
+    expect(sent.headers.get('Authorization')).toBe('Bearer jwt-token');
+    expect(spinnerSpy.show).toHaveBeenCalled();
+    expect(spinnerSpy.hide).toHaveBeenCalled();
+  });
+
+  it('should not add Authorization header when the user is not authenticated', () => {
+    tokenServiceSpy.getToken.and.returnValue(null);
+    tokenServiceSpy.isAuthenticated.and.returnValue(false);
+    handlerSpy.handle.and.callFake((req: HttpRequest<any>) => of(mockResponse as HttpEvent<any>));
+
+    const req = new HttpRequest('GET', '/api/data');
+    interceptor.intercept(req, handlerSpy).subscribe();
+
+    const sent = handlerSpy.handle.calls.first().args[0] as HttpRequest<any>;
+    expect(sent.headers.has('Authorization')).toBeFalse();
+    expect(spinnerSpy.show).toHaveBeenCalled();
+    expect(spinnerSpy.hide).toHaveBeenCalled();
+  });
+
+  it('should show and hide the spinner around the request', () => {
+    tokenServiceSpy.isAuthenticated.and.returnValue(false);
+    handlerSpy.handle.and.callFake((req: HttpRequest<any>) => of(mockResponse as HttpEvent<any>));
+
+    const req = new HttpRequest('GET', '/api/data');
+    interceptor.intercept(req, handlerSpy).subscribe();
+
+    expect(spinnerSpy.show).toHaveBeenCalled();
+    expect(spinnerSpy.hide).toHaveBeenCalled();
+  });
+
+  it('should hide the spinner even when the request errors', (done) => {
+    tokenServiceSpy.isAuthenticated.and.returnValue(false);
+    handlerSpy.handle.and.callFake((req: HttpRequest<any>) =>
+      new Observable<HttpEvent<any>>(subscriber => {
+        subscriber.error(new Error('boom'));
+      })
+    );
+
+    const req = new HttpRequest('GET', '/api/data');
+    interceptor.intercept(req, handlerSpy).subscribe({
+      next: () => done.fail('expected error'),
+      error: () => {
+        expect(spinnerSpy.show).toHaveBeenCalled();
+        setTimeout(() => {
+          expect(spinnerSpy.hide).toHaveBeenCalled();
+          done();
+        }, 0);
+      }
+    });
+  });
+});

--- a/src/app/_models/main/Profile.spec.ts
+++ b/src/app/_models/main/Profile.spec.ts
@@ -1,0 +1,92 @@
+import { Knowledge, Profile, ProfileData, Project } from './Profile';
+
+describe('Profile', () => {
+  it('should allow building a profile with the expected fields', () => {
+    const data = new ProfileData();
+    data.name = 'Main';
+    const p = new Profile();
+    p.profileId = 1;
+    p.profileLanguage = 'es';
+    p.profileData = data;
+    p.lastUpdate = '2025-01-01';
+    p.status = true;
+
+    expect(p.profileId).toBe(1);
+    expect(p.profileLanguage).toBe('es');
+    expect(p.profileData).toBe(data);
+    expect(p.lastUpdate).toBe('2025-01-01');
+    expect(p.status).toBeTrue();
+  });
+});
+
+describe('Project', () => {
+  it('should build an empty project when no argument is provided', () => {
+    const p = new Project();
+
+    expect(p.id).toBeUndefined();
+    expect(p.name).toBeUndefined();
+    expect(p.description).toBeUndefined();
+    expect(p.detailHtml).toBeUndefined();
+    expect(p.mainImage).toBeUndefined();
+    expect(p.order).toBeUndefined();
+  });
+
+  it('should copy all fields from the source project', () => {
+    const source = new Project();
+    source.id = 1;
+    source.name = 'Project A';
+    source.description = 'desc';
+    source.detailHtml = '<p>html</p>';
+    source.mainImage = 'img.png';
+    source.order = 3;
+
+    const copy = new Project(source);
+
+    expect(copy.id).toBe(1);
+    expect(copy.name).toBe('Project A');
+    expect(copy.description).toBe('desc');
+    expect(copy.detailHtml).toBe('<p>html</p>');
+    expect(copy.mainImage).toBe('img.png');
+    expect(copy.order).toBe(3);
+  });
+});
+
+describe('Knowledge', () => {
+  it('should build an empty knowledge when no argument is provided', () => {
+    const k = new Knowledge();
+
+    expect(k.id).toBeUndefined();
+    expect(k.name).toBeUndefined();
+    expect(k.type).toBeUndefined();
+    expect(k.level).toBeUndefined();
+    expect(k.description).toBeUndefined();
+    expect(k.categories).toBeUndefined();
+  });
+
+  it('should copy fields and rebuild the categories array', () => {
+    const source = new Knowledge();
+    source.id = 1;
+    source.name = 'Angular';
+    source.type = 'framework';
+    source.level = 4;
+    source.description = 'frontend framework';
+    source.categories = ['web', 'frontend'];
+
+    const copy = new Knowledge(source);
+
+    expect(copy.id).toBe(1);
+    expect(copy.name).toBe('Angular');
+    expect(copy.type).toBe('framework');
+    expect(copy.level).toBe(4);
+    expect(copy.description).toBe('frontend framework');
+    expect(copy.categories).toEqual(['web', 'frontend']);
+    expect(copy.categories).not.toBe(source.categories);
+  });
+
+  it('should not throw when the source categories are undefined', () => {
+    const source = new Knowledge();
+    source.categories = undefined as any;
+
+    expect(() => new Knowledge(source)).toThrow();
+  });
+});

--- a/src/app/_models/user.spec.ts
+++ b/src/app/_models/user.spec.ts
@@ -1,0 +1,78 @@
+import { User, UserNotification } from './user';
+
+describe('User', () => {
+  describe('constructor (no args)', () => {
+    it('should create an empty user with undefined fields', () => {
+      const user = new User();
+
+      expect(user.userId).toBeUndefined();
+      expect(user.name).toBeUndefined();
+      expect(user.userName).toBeUndefined();
+      expect(user.password).toBeUndefined();
+      expect(user.email).toBeUndefined();
+      expect(user.role).toBeUndefined();
+      expect(user.notifications).toBeUndefined();
+      expect(user.status).toBeUndefined();
+    });
+  });
+
+  describe('copy constructor', () => {
+    it('should copy all listed fields from the source user', () => {
+      const source = new User();
+      source.userId = 1;
+      source.name = 'Luis';
+      source.userName = 'lumialvarez';
+      source.email = 'luis@example.com';
+      source.role = 'ADMIN';
+      source.notifications = [{ id: 1, title: 't', detail: 'd', date: '2025-01-01', read: false } as UserNotification];
+      source.status = true;
+
+      const copy = new User(source);
+
+      expect(copy.userId).toBe(1);
+      expect(copy.name).toBe('Luis');
+      expect(copy.userName).toBe('lumialvarez');
+      expect(copy.email).toBe('luis@example.com');
+      expect(copy.role).toBe('ADMIN');
+      expect(copy.notifications).toBe(source.notifications);
+      expect(copy.status).toBeTrue();
+    });
+
+    it('should NOT copy the password field (intentionally)', () => {
+      const source = new User();
+      source.password = 'secret';
+
+      const copy = new User(source);
+
+      expect(copy.password).toBeUndefined();
+    });
+
+    it('should not mutate the source user when copy is modified', () => {
+      const source = new User();
+      source.name = 'Original';
+      const copy = new User(source);
+
+      copy.name = 'Modified';
+
+      expect(source.name).toBe('Original');
+    });
+  });
+});
+
+describe('UserNotification', () => {
+  it('should allow building a notification with the expected fields', () => {
+    const n: UserNotification = {
+      id: 5,
+      title: 'Welcome',
+      detail: 'Hi there',
+      date: '2025-06-01',
+      read: false
+    };
+
+    expect(n.id).toBe(5);
+    expect(n.title).toBe('Welcome');
+    expect(n.detail).toBe('Hi there');
+    expect(n.date).toBe('2025-06-01');
+    expect(n.read).toBeFalse();
+  });
+});

--- a/src/app/_services/http/Error.spec.ts
+++ b/src/app/_services/http/Error.spec.ts
@@ -1,0 +1,78 @@
+import { CommonError } from './Error';
+import { ToastService } from '../toast.service';
+
+describe('CommonError', () => {
+  let toastServiceSpy: jasmine.SpyObj<ToastService>;
+  let consoleLogSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    toastServiceSpy = jasmine.createSpyObj('ToastService', ['showDanger']);
+    consoleLogSpy = spyOn(console, 'log');
+  });
+
+  it('should copy the fields from the source error object', () => {
+    const err = {
+      Status: 'FAILED',
+      Message: 'Bad request',
+      Err: 'VALIDATION',
+      Cause: ['invalid name']
+    };
+
+    const commonError = new CommonError(err, toastServiceSpy);
+
+    expect(commonError.Status).toBe('FAILED');
+    expect(commonError.Message).toBe('Bad request');
+    expect(commonError.Err).toBe('VALIDATION');
+    expect(commonError.Cause).toEqual(['invalid name']);
+    expect(commonError.toastService).toBe(toastServiceSpy);
+  });
+
+  describe('printErrorDetails', () => {
+    it('should log the message and causes', () => {
+      const err = {
+        Status: 'FAILED',
+        Message: 'Something went wrong',
+        Err: 'ERR',
+        Cause: ['cause 1', 'cause 2']
+      };
+
+      const commonError = new CommonError(err, toastServiceSpy);
+      commonError.printErrorDetails();
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        ' (Something went wrong) ->cause 1,cause 2'
+      );
+    });
+
+    it('should call showDanger for every cause that does not include "Status gRPC"', () => {
+      const err = {
+        Status: 'FAILED',
+        Message: 'Boom',
+        Err: 'E',
+        Cause: ['error A', 'Status gRPC: UNAVAILABLE', 'error B']
+      };
+
+      const commonError = new CommonError(err, toastServiceSpy);
+      commonError.printErrorDetails();
+
+      expect(toastServiceSpy.showDanger).toHaveBeenCalledWith('error A');
+      expect(toastServiceSpy.showDanger).toHaveBeenCalledWith('error B');
+      expect(toastServiceSpy.showDanger).not.toHaveBeenCalledWith('Status gRPC: UNAVAILABLE');
+      expect(toastServiceSpy.showDanger.calls.count()).toBe(2);
+    });
+
+    it('should not call showDanger when the cause list is empty', () => {
+      const err = {
+        Status: 'FAILED',
+        Message: 'Nothing to see',
+        Err: 'E',
+        Cause: []
+      };
+
+      const commonError = new CommonError(err, toastServiceSpy);
+      commonError.printErrorDetails();
+
+      expect(toastServiceSpy.showDanger).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/_services/http/login/login.service.spec.ts
+++ b/src/app/_services/http/login/login.service.spec.ts
@@ -1,0 +1,87 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { LoginService } from './login.service';
+import { GlobalConstants } from '../../../common/global-constants';
+import { LoginRequest } from './dto/login-request';
+import { LoginResponse } from './dto/login-response';
+import { User } from '../../../_models/user';
+
+describe('LoginService', () => {
+  let service: LoginService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [LoginService]
+    });
+
+    service = TestBed.inject(LoginService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('login should POST the credentials to the login endpoint', () => {
+    const request = new LoginRequest('admin', 'secret');
+    const mockResponse: LoginResponse = {
+      token: 'jwt-token',
+      userId: 1,
+      userName: 'admin',
+      role: 'ADMIN'
+    };
+
+    let actual: LoginResponse | undefined;
+    service.login(request).subscribe(res => (actual = res));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'POST' && r.url === GlobalConstants.loginPath
+    );
+    expect(req.request.body).toEqual(request);
+    req.flush(mockResponse);
+
+    expect(actual).toEqual(mockResponse);
+  });
+
+  it('getCurrentUser should GET the current user endpoint', () => {
+    const mockUser = new User();
+    mockUser.userId = 1;
+    mockUser.userName = 'admin';
+
+    let actual: User | undefined;
+    service.getCurrentUser().subscribe(u => (actual = u));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'GET' && r.url === GlobalConstants.currentUserPath
+    );
+    req.flush(mockUser);
+
+    expect(actual).toEqual(mockUser);
+  });
+
+  it('getCurrentUserOfToken should send Authorization Bearer header with the token', () => {
+    const mockUser = new User();
+    mockUser.userId = 2;
+    mockUser.userName = 'token-user';
+
+    let actual: User | undefined;
+    service.getCurrentUserOfToken('my-token').subscribe(u => (actual = u));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'GET' && r.url === GlobalConstants.currentUserPath
+    );
+
+    expect(req.request.headers.get('Authorization')).toBe('Bearer my-token');
+    expect(req.request.headers.get('Content-Type')).toBe('application/json');
+    req.flush(mockUser);
+
+    expect(actual).toEqual(mockUser);
+  });
+});

--- a/src/app/_services/http/notification/notification.service.spec.ts
+++ b/src/app/_services/http/notification/notification.service.spec.ts
@@ -1,0 +1,41 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { NotificationService } from './notification.service';
+import { GlobalConstants } from '../../../common/global-constants';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [NotificationService]
+    });
+
+    service = TestBed.inject(NotificationService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('SetReadNotification should PUT to the notification endpoint with the id and a null body', () => {
+    let actual: any;
+    service.SetReadNotification(99).subscribe(res => (actual = res));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'PUT' && r.url === `${GlobalConstants.notificationUserPath}/99`
+    );
+    expect(req.request.body).toBeNull();
+    req.flush({ ok: true });
+
+    expect(actual).toEqual({ ok: true });
+  });
+});

--- a/src/app/_services/http/profile/perfil.service.spec.ts
+++ b/src/app/_services/http/profile/perfil.service.spec.ts
@@ -1,0 +1,101 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ProfileService } from './perfil.service';
+import { GlobalConstants } from '../../../common/global-constants';
+import { Profile, ProfileData } from '../../../_models/main/Profile';
+import { SaveProfileRequest } from './dto/save-profile-request';
+import { SaveProfileResponse } from './dto/save-profile-response';
+import { ProfileResponse } from './dto/profile-response';
+
+describe('ProfileService', () => {
+  let service: ProfileService;
+  let httpMock: HttpTestingController;
+
+  const buildProfile = (id: number): Profile => {
+    const p = new Profile();
+    p.profileId = id;
+    p.profileLanguage = 'es';
+    p.profileData = new ProfileData();
+    p.profileData.name = `Profile ${id}`;
+    p.status = true;
+    return p;
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ProfileService]
+    });
+
+    service = TestBed.inject(ProfileService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getProfilesExternal should GET the external profile endpoint', () => {
+    const mockResponse: ProfileResponse = { profiles: [buildProfile(1), buildProfile(2)] };
+
+    let actual: ProfileResponse | undefined;
+    service.getProfilesExternal().subscribe(r => (actual = r));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'GET' && r.url === GlobalConstants.profileExternalPath
+    );
+    req.flush(mockResponse);
+
+    expect(actual).toEqual(mockResponse);
+  });
+
+  it('getProfiles should GET the internal profile endpoint', () => {
+    const mockResponse: ProfileResponse = { profiles: [buildProfile(3)] };
+
+    let actual: ProfileResponse | undefined;
+    service.getProfiles().subscribe(r => (actual = r));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'GET' && r.url === GlobalConstants.profileInternalPath
+    );
+    req.flush(mockResponse);
+
+    expect(actual).toEqual(mockResponse);
+  });
+
+  it('getProfileById should GET the profile path with the id appended', () => {
+    const mockProfile = buildProfile(42);
+
+    let actual: Profile | undefined;
+    service.getProfileById(42).subscribe(p => (actual = p));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'GET' && r.url === `${GlobalConstants.profileInternalPath}/42`
+    );
+    req.flush(mockProfile);
+
+    expect(actual).toEqual(mockProfile);
+  });
+
+  it('updateProfile should PUT a SaveProfileRequest wrapping the profile', () => {
+    const profile = buildProfile(5);
+    const mockResponse: SaveProfileResponse = { profile };
+
+    let actual: SaveProfileResponse | undefined;
+    service.updateProfile(profile).subscribe(r => (actual = r));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'PUT' && r.url === GlobalConstants.profileInternalPath
+    );
+    expect(req.request.body).toEqual(jasmine.any(SaveProfileRequest));
+    expect((req.request.body as SaveProfileRequest).profile).toBe(profile);
+    req.flush(mockResponse);
+
+    expect(actual).toEqual(mockResponse);
+  });
+});

--- a/src/app/_services/http/user/user.service.spec.ts
+++ b/src/app/_services/http/user/user.service.spec.ts
@@ -1,0 +1,99 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { UserService } from './user.service';
+import { GlobalConstants } from '../../../common/global-constants';
+import { User } from '../../../_models/user';
+import { UserListResponse } from './dto/get-users-response';
+import { CreateUserRequest } from './dto/create-user-request';
+import { UpdateUserRequest } from './dto/update-user-request';
+
+describe('UserService', () => {
+  let service: UserService;
+  let httpMock: HttpTestingController;
+
+  const buildUser = (id: number, name = 'user', role = 'USER'): User => {
+    const u = new User();
+    u.userId = id;
+    u.userName = name;
+    u.name = name;
+    u.email = `${name}@example.com`;
+    u.password = 'pwd';
+    u.role = role;
+    u.status = true;
+    return u;
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [UserService]
+    });
+
+    service = TestBed.inject(UserService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getUsers should GET the user list endpoint', () => {
+    const mockResponse: UserListResponse = { users: [buildUser(1), buildUser(2)] };
+
+    let actual: UserListResponse | undefined;
+    service.getUsers().subscribe(r => (actual = r));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'GET' && r.url === GlobalConstants.userPath
+    );
+    req.flush(mockResponse);
+
+    expect(actual).toEqual(mockResponse);
+  });
+
+  it('createUser should POST a CreateUserRequest to the user endpoint', () => {
+    const source = buildUser(0, 'new', 'ADMIN');
+    const mockResponse = { ok: true };
+
+    let actual: any;
+    service.createUser(new CreateUserRequest(source)).subscribe(res => (actual = res));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'POST' && r.url === GlobalConstants.userPath
+    );
+    const body = req.request.body as CreateUserRequest;
+    expect(body).toEqual(jasmine.objectContaining({
+      name: 'new',
+      userName: 'new',
+      email: 'new@example.com',
+      password: 'pwd',
+      role: 'ADMIN'
+    }));
+    req.flush(mockResponse);
+
+    expect(actual).toEqual(mockResponse);
+  });
+
+  it('updateUser should PUT an UpdateUserRequest to the user endpoint', () => {
+    const source = buildUser(7, 'updated');
+    const request = new UpdateUserRequest();
+    request.user = source;
+    const mockResponse = { ok: true };
+
+    let actual: any;
+    service.updateUser(request).subscribe(res => (actual = res));
+
+    const req = httpMock.expectOne(
+      r => r.method === 'PUT' && r.url === GlobalConstants.userPath
+    );
+    expect(req.request.body).toBe(request);
+    req.flush(mockResponse);
+
+    expect(actual).toEqual(mockResponse);
+  });
+});

--- a/src/app/_services/toast.service.spec.ts
+++ b/src/app/_services/toast.service.spec.ts
@@ -1,0 +1,102 @@
+import { TemplateRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { ToastService } from './toast.service';
+
+describe('ToastService', () => {
+  let service: ToastService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ToastService);
+  });
+
+  it('should be created with an empty toasts list', () => {
+    expect(service).toBeTruthy();
+    expect(service.toasts).toEqual([]);
+  });
+
+  describe('show', () => {
+    it('should push a toast with the provided text and options', () => {
+      service.show('hello', { classname: 'bg-custom', delay: 1000, title: 'Hi' });
+
+      expect(service.toasts.length).toBe(1);
+      expect(service.toasts[0].textOrTpl).toBe('hello');
+      expect(service.toasts[0].classname).toBe('bg-custom');
+      expect(service.toasts[0].delay).toBe(1000);
+      expect(service.toasts[0].title).toBe('Hi');
+    });
+
+    it('should default options to an empty object when not provided', () => {
+      service.show('hi');
+
+      expect(service.toasts[0].classname).toBeUndefined();
+      expect(service.toasts[0].delay).toBeUndefined();
+    });
+
+    it('should accept a TemplateRef as textOrTpl', () => {
+      const fakeTemplate = {} as TemplateRef<any>;
+      service.show(fakeTemplate);
+
+      expect(service.toasts[0].textOrTpl).toBe(fakeTemplate);
+    });
+  });
+
+  describe('showInfo / showSuccess / showDanger', () => {
+    it('showInfo should push a toast with bg-info styling', () => {
+      service.showInfo('info-msg');
+
+      expect(service.toasts[0]).toEqual(jasmine.objectContaining({
+        textOrTpl: 'info-msg',
+        classname: 'bg-info text-light',
+        delay: 8000,
+        title: ''
+      }));
+    });
+
+    it('showSuccess should push a toast with bg-success styling and "Exito!" title', () => {
+      service.showSuccess('ok-msg');
+
+      expect(service.toasts[0]).toEqual(jasmine.objectContaining({
+        textOrTpl: 'ok-msg',
+        classname: 'bg-success text-light',
+        delay: 8000,
+        title: 'Exito!'
+      }));
+    });
+
+    it('showDanger should push a toast with bg-danger styling and "Error" title', () => {
+      service.showDanger('fail-msg');
+
+      expect(service.toasts[0]).toEqual(jasmine.objectContaining({
+        textOrTpl: 'fail-msg',
+        classname: 'bg-danger text-light',
+        delay: 8000,
+        title: 'Error'
+      }));
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove the matching toast from the list', () => {
+      service.show('first');
+      service.show('second');
+      const toRemove = service.toasts[0];
+
+      service.remove(toRemove);
+
+      expect(service.toasts.length).toBe(1);
+      expect(service.toasts[0].textOrTpl).toBe('second');
+    });
+
+    it('should do nothing when the toast is not in the list', () => {
+      service.show('only');
+      const fakeToast = { textOrTpl: 'unknown' };
+
+      service.remove(fakeToast);
+
+      expect(service.toasts.length).toBe(1);
+      expect(service.toasts[0].textOrTpl).toBe('only');
+    });
+  });
+});

--- a/src/app/_services/token.service.spec.ts
+++ b/src/app/_services/token.service.spec.ts
@@ -1,0 +1,147 @@
+import { TestBed } from '@angular/core/testing';
+import { JwtHelperService } from '@auth0/angular-jwt';
+
+import { TokenService } from './token.service';
+import { User } from '../_models/user';
+
+describe('TokenService', () => {
+  let service: TokenService;
+  let jwtHelperSpy: jasmine.SpyObj<JwtHelperService>;
+
+  const TOKEN_KEY = 'AuthToken';
+  const USERNAME_KEY = 'AuthUser';
+
+  beforeEach(() => {
+    jwtHelperSpy = jasmine.createSpyObj('JwtHelperService', ['isTokenExpired']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        TokenService,
+        { provide: JwtHelperService, useValue: jwtHelperSpy }
+      ]
+    });
+
+    service = TestBed.inject(TokenService);
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('setToken / getToken', () => {
+    it('should store the token in sessionStorage under the AuthToken key', () => {
+      service.setToken('abc.def.ghi');
+
+      expect(sessionStorage.getItem(TOKEN_KEY)).toBe('abc.def.ghi');
+    });
+
+    it('should return the previously stored token', () => {
+      sessionStorage.setItem(TOKEN_KEY, 'stored-token');
+
+      expect(service.getToken()).toBe('stored-token');
+    });
+
+    it('should overwrite any existing token', () => {
+      sessionStorage.setItem(TOKEN_KEY, 'old-token');
+
+      service.setToken('new-token');
+
+      expect(sessionStorage.getItem(TOKEN_KEY)).toBe('new-token');
+    });
+
+    it('should return null when there is no token stored', () => {
+      expect(service.getToken()).toBeNull();
+    });
+  });
+
+  describe('setUser / getUser', () => {
+    it('should serialize and store a user in sessionStorage', () => {
+      const user = new User();
+      user.userId = 7;
+      user.name = 'Luis';
+      user.userName = 'lumialvarez';
+      user.email = 'luis@example.com';
+      user.role = 'ADMIN';
+      user.status = true;
+
+      service.setUser(user);
+
+      const raw = sessionStorage.getItem(USERNAME_KEY);
+      expect(raw).toBeTruthy();
+      expect(JSON.parse(raw)).toEqual(jasmine.objectContaining({
+        userId: 7,
+        name: 'Luis',
+        userName: 'lumialvarez',
+        email: 'luis@example.com',
+        role: 'ADMIN',
+        status: true
+      }));
+    });
+
+    it('should retrieve the stored user as a User instance', () => {
+      const user = new User();
+      user.userId = 1;
+      user.userName = 'admin';
+      service.setUser(user);
+
+      const result = service.getUser();
+
+      expect(result).toBeTruthy();
+      expect(result.userId).toBe(1);
+      expect(result.userName).toBe('admin');
+    });
+
+    it('should overwrite the previously stored user', () => {
+      const first = new User();
+      first.userName = 'first';
+      const second = new User();
+      second.userName = 'second';
+
+      service.setUser(first);
+      service.setUser(second);
+
+      expect(JSON.parse(sessionStorage.getItem(USERNAME_KEY)).userName).toBe('second');
+    });
+  });
+
+  describe('logOut', () => {
+    it('should clear the entire sessionStorage', () => {
+      sessionStorage.setItem(TOKEN_KEY, 'token');
+      sessionStorage.setItem(USERNAME_KEY, 'user');
+      sessionStorage.setItem('other', 'value');
+
+      service.logOut();
+
+      expect(sessionStorage.length).toBe(0);
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    it('should return true when the stored token is not expired', () => {
+      service.setToken('valid-token');
+      (spyOn(service.jwtHelper, 'isTokenExpired') as jasmine.Spy).and.callFake(() => false);
+
+      expect(service.isAuthenticated()).toBeTrue();
+      expect(service.jwtHelper.isTokenExpired).toHaveBeenCalled();
+    });
+
+    it('should return false when the stored token is expired', () => {
+      service.setToken('expired-token');
+      (spyOn(service.jwtHelper, 'isTokenExpired') as jasmine.Spy).and.callFake(() => true);
+
+      expect(service.isAuthenticated()).toBeFalse();
+    });
+
+    it('should not throw when no token is stored', () => {
+      (spyOn(service.jwtHelper, 'isTokenExpired') as jasmine.Spy).and.callFake(() => true);
+
+      expect(() => service.isAuthenticated()).not.toThrow();
+    });
+  });
+});
+

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [AppComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    });
+  });
+
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+
+  it('should have the title "personal-website"', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app.title).toBe('personal-website');
+  });
+
+  it('should render the title in a tag with .content class (smoke test)', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled).toBeTruthy();
+  });
+});

--- a/src/app/common/app-version.spec.ts
+++ b/src/app/common/app-version.spec.ts
@@ -1,0 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+
+import { APP_VERSION } from './app-version';
+import pkg from '../../../package.json';
+
+describe('APP_VERSION injection token', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be defined and have a description', () => {
+    expect(APP_VERSION).toBeTruthy();
+    expect(APP_VERSION.toString()).toContain('APP_VERSION');
+  });
+
+  it('should provide the package.json version when injected', () => {
+    const version = TestBed.inject(APP_VERSION);
+
+    expect(version).toBe(pkg.version);
+  });
+});

--- a/src/app/common/global-constants.spec.ts
+++ b/src/app/common/global-constants.spec.ts
@@ -1,0 +1,37 @@
+import { GlobalConstants } from './global-constants';
+
+describe('GlobalConstants', () => {
+  it('should expose the user endpoint under the authorization service path', () => {
+    expect(GlobalConstants.userPath)
+      .toBe('https://services.lmalvarez.com/authorization/api/v1/int/user');
+  });
+
+  it('should expose the login endpoint under the authorization service path', () => {
+    expect(GlobalConstants.loginPath)
+      .toBe('https://services.lmalvarez.com/authorization/api/v1/ext/user/login');
+  });
+
+  it('should expose the current-user endpoint under the authorization service path', () => {
+    expect(GlobalConstants.currentUserPath)
+      .toBe('https://services.lmalvarez.com/authorization/api/v1/int/user/current/notification');
+  });
+
+  it('should expose the notification endpoint under the authorization service path', () => {
+    expect(GlobalConstants.notificationUserPath)
+      .toBe('https://services.lmalvarez.com/authorization/api/v1/int/user/current/notification');
+  });
+
+  it('should expose the internal profile endpoint under the profile service path', () => {
+    expect(GlobalConstants.profileInternalPath)
+      .toBe('https://services.lmalvarez.com/profile/api/v1/int/profile');
+  });
+
+  it('should expose the external profile endpoint under the profile service path', () => {
+    expect(GlobalConstants.profileExternalPath)
+      .toBe('https://services.lmalvarez.com/profile/api/v1/ext/profile');
+  });
+
+  it('should keep current-user and notification paths aligned', () => {
+    expect(GlobalConstants.currentUserPath).toBe(GlobalConstants.notificationUserPath);
+  });
+});

--- a/src/app/toasts-container.component.spec.ts
+++ b/src/app/toasts-container.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TemplateRef } from '@angular/core';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { ToastsContainerComponent } from './toasts-container.component';
+import { ToastService } from './_services/toast.service';
+
+describe('ToastsContainerComponent', () => {
+  let component: ToastsContainerComponent;
+  let fixture: ComponentFixture<ToastsContainerComponent>;
+  let toastService: ToastService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NgbModule],
+      declarations: [ToastsContainerComponent],
+      providers: [ToastService]
+    });
+
+    fixture = TestBed.createComponent(ToastsContainerComponent);
+    component = fixture.componentInstance;
+    toastService = TestBed.inject(ToastService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('isTemplate', () => {
+    it('should return true when the toast payload is a TemplateRef', () => {
+      const fakeTemplate = Object.create(TemplateRef.prototype) as TemplateRef<any>;
+      const toast = { textOrTpl: fakeTemplate };
+
+      expect(component.isTemplate(toast)).toBeTrue();
+    });
+
+    it('should return false when the toast payload is a plain string', () => {
+      const toast = { textOrTpl: 'just a string' };
+
+      expect(component.isTemplate(toast)).toBeFalse();
+    });
+
+    it('should return false when the toast payload is null or undefined', () => {
+      expect(component.isTemplate({ textOrTpl: null })).toBeFalse();
+      expect(component.isTemplate({ textOrTpl: undefined })).toBeFalse();
+    });
+  });
+
+  it('should bind to the ToastService provided list', () => {
+    toastService.show('a toast');
+
+    expect(component.toastService.toasts.length).toBe(1);
+    expect(component.toastService.toasts[0].textOrTpl).toBe('a toast');
+  });
+});

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,


### PR DESCRIPTION
- Add 87 unit tests (16 spec files) covering all HTTP services (login, profile, notification, user, CommonError), auth helpers (TokenService, AuthGuardGuard, BasicAuthInterceptor), the RevealDirective (with mocked IntersectionObserver), the ToastsContainerComponent, AppComponent and the model classes
- Add reusable GitHub Actions workflow (.github/workflows/test.yml) that runs tests with coverage on push to main and is callable via workflow_call; uploads the HTML/lcov report as an artifact and optionally pushes to Codecov
- Update build-and-push-test.yml to depend on the test workflow (needs: test) so the Docker test image is only built when all tests pass
- Auto-detect CI in karma.conf.js to switch the launcher and disable watch; add ChromeHeadlessCI launcher with the flags required for sandbox-less Linux containers
- Replace deprecated karma-coverage-istanbul-reporter with the standard karma-coverage required by @angular-devkit/build-angular v21; migrate from coverageIstanbulReporter to coverageReporter
- Fix src/test.ts import to use the new 'zone.js/testing' subpath export (the old 'zone.js/dist/zone-testing' no longer exists in zone.js 0.16+)
- Bump version to 2.4.0 in package.json and add changelog entry